### PR TITLE
Added total balance and individual token balances, and wallet activity calculation period

### DIFF
--- a/src/components/BasicsCard.tsx
+++ b/src/components/BasicsCard.tsx
@@ -1,6 +1,6 @@
-import { FC, useEffect, useState } from 'react';
-import { getBalance, getLastInteraction } from '../services/explorer.ts';
-import { getTimeAgo } from '../utils/utils.ts';
+import {FC, useEffect, useState} from 'react';
+import {getBalance, getLastInteraction, Token} from '../services/explorer.ts';
+import {getTimeAgo} from '../utils/utils.ts';
 
 interface BasicsCardInfo {
   address: string;
@@ -8,6 +8,10 @@ interface BasicsCardInfo {
   totalBalance: string | number;
   totalVolume: string;
   lastActivity: string;
+  tokenBalances: Token[];
+  activeDays: number;
+  activeWeeks: number;
+  activeMonths: { [month: string]: number };
 }
 
 const getTotalVolume = (transactionList: any[]) => {
@@ -28,9 +32,52 @@ const getTotalVolume = (transactionList: any[]) => {
       10 ** -erc20Transfers[0].tokenInfo.decimals *
       erc20Transfers[0].tokenInfo.usdPrice;
   });
-
   return totalVolume.toFixed(2);
 };
+
+
+interface ActiveTimePeriods {
+  activeDays: number;
+  activeWeeks: number;
+  activeMonths: { [month: string]: number };
+}
+
+function getWeek(date: Date): number {
+  const tempDate = new Date(date.getTime());
+  tempDate.setHours(0, 0, 0, 0);
+  tempDate.setDate(tempDate.getDate() + 3 - ((tempDate.getDay() + 6) % 7));
+  const week1 = new Date(tempDate.getFullYear(), 0, 4);
+  return 1 + Math.round(((tempDate.getTime() - week1.getTime()) / 86400000 - 3 + ((week1.getDay() + 6) % 7)) / 7);
+}
+
+const getActiveTimePeriods = (transactionList: any[]): ActiveTimePeriods => {
+  const uniqueDates = new Set<string>();
+  const uniqueWeeks = new Set<string>();
+  const uniqueMonths: { [month: string]: number } = {};
+
+  transactionList.forEach((transaction) => {
+    const date = new Date(transaction.receivedAt);
+    const dateString = date.toLocaleDateString();
+    const weekString = `${date.getFullYear()}-W${getWeek(date)}`;
+    const monthString = date.toLocaleString('default', { month: 'long' });
+
+    uniqueDates.add(dateString);
+    uniqueWeeks.add(weekString);
+
+    if (uniqueMonths[monthString]) {
+      uniqueMonths[monthString]++;
+    } else {
+      uniqueMonths[monthString] = 1;
+    }
+  });
+
+  return {
+    activeDays: uniqueDates.size,
+    activeWeeks: uniqueWeeks.size,
+    activeMonths: uniqueMonths,
+  };
+};
+
 
 const BasicsCard: FC<{ address: string; transactionList: any[] }> = ({ address, transactionList }) => {
   const [cardInfo, setCardInfo] = useState<BasicsCardInfo>({
@@ -39,16 +86,27 @@ const BasicsCard: FC<{ address: string; transactionList: any[] }> = ({ address, 
     totalBalance: 0,
     totalVolume: 'NaN',
     lastActivity: 'NaN',
+    tokenBalances: [],
+    activeDays: 0,
+    activeWeeks: 0,
+    activeMonths: {},
   });
 
   useEffect(() => {
     const fetchInfo = async () => {
+      const tokenBalances = await getBalance(address);
+      const totalBalance = tokenBalances.reduce((acc, token) => acc + token.balance, 0);
+
       setCardInfo({
         address: address,
         totalInteractions: transactionList ? transactionList.length : 0,
-        totalBalance: await getBalance(address),
+        totalBalance,
         totalVolume: getTotalVolume(transactionList),
         lastActivity: getTimeAgo(await getLastInteraction(address)),
+        tokenBalances,
+        activeDays: getActiveTimePeriods(transactionList).activeDays,
+        activeWeeks: getActiveTimePeriods(transactionList).activeWeeks,
+        activeMonths: getActiveTimePeriods(transactionList).activeMonths,
       });
     };
     fetchInfo();
@@ -74,10 +132,29 @@ const BasicsCard: FC<{ address: string; transactionList: any[] }> = ({ address, 
             <dt className="mb-2 text-3xl font-extrabold">{cardInfo?.lastActivity}</dt>
             <dd className="text-gray-400">Last activity</dd>
           </div>
+          <div className="flex flex-col items-center justify-center">
+            <dt className="mb-2 text-3xl font-extrabold">{cardInfo?.activeDays}</dt>
+            <dd className="text-gray-400">Active Days</dd>
+          </div>
+          <div className="flex flex-col items-center justify-center">
+            <dt className="mb-2 text-3xl font-extrabold">{cardInfo?.activeWeeks}</dt>
+            <dd className="text-gray-400">Active Weeks</dd>
+          </div><br></br>
+          <div className="flex flex-col items-center justify-center">
+            <dt className="mb-2 text-3xl font-extrabold">{Object.keys(cardInfo?.activeMonths).length}</dt>
+            <dd className="text-gray-400">Active Months</dd>
+          </div>
+          {cardInfo.tokenBalances.map((token) => (
+            <div key={token.symbol} className="flex flex-col items-center justify-center">
+              <dt className="mb-2 text-3xl font-extrabold">${Number(token.balance).toFixed(2)}</dt>
+              <dd className="text-gray-400">{token.symbol} Balance</dd>
+            </div>
+          ))}
         </>
       </div>
     </div>
   );
 };
+
 
 export default BasicsCard;

--- a/src/services/explorer.ts
+++ b/src/services/explorer.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse } from 'axios';
+import axios, {AxiosResponse} from 'axios';
 
 export interface Token {
   balance: number;
@@ -30,24 +30,21 @@ const getERC721 = async (address: string): Promise<Token[]> => {
   return tokenList.filter((token: Token) => token.type === 'ERC-721');
 };
 
-const getBalance = async (address: string): Promise<string | number> => {
-  return axios
-    .get(`https://zksync2-mainnet-explorer.zksync.io/address/${address}`)
-    .then((res) => {
-      const ethInfo = res.data.info.balances['0x0000000000000000000000000000000000000000'];
-      if (!ethInfo) return 'NaN';
-      const ethBalance = (
-        parseInt(ethInfo.balance, 16) *
-        10 ** -ethInfo.tokenInfo.decimals *
-        ethInfo.tokenInfo.usdPrice
-      ).toFixed(2);
-      return parseInt(ethBalance);
-    })
-    .catch((err) => {
-      console.log(err);
-      return 'NaN';
+const getBalance = async (address: string): Promise<Token[]> => {
+  const response: AxiosResponse = await axios.get(`https://zksync2-mainnet-explorer.zksync.io/address/${address}`);
+  const balances = response.data.info.balances;
+  const tokenBalances: Token[] = [];
+  for (const tokenAddress in balances) {
+    const tokenInfo = balances[tokenAddress].tokenInfo;
+    const balance = parseFloat((parseInt(balances[tokenAddress].balance, 16) * 10 ** -tokenInfo.decimals * tokenInfo.usdPrice).toFixed(2));
+    tokenBalances.push({
+      ...tokenInfo,
+      balance,
     });
+  }
+  return tokenBalances;
 };
+
 
 const getLastInteraction = async (address: string): Promise<string> => {
   return axios
@@ -80,7 +77,6 @@ const getAllTransactions = async (address: string): Promise<any[]> => {
 
     try {
       const response: AxiosResponse = await axios.get(baseUrl, { params });
-
       if (response.status === 200) {
         const data = response.data.list;
         transactions.push(...data);
@@ -99,4 +95,5 @@ const getAllTransactions = async (address: string): Promise<any[]> => {
   return transactions;
 };
 
-export { getERC20, getERC721, getBalance, getLastInteraction, getAllTransactions };
+
+export {getERC20, getERC721, getBalance, getLastInteraction, getAllTransactions};


### PR DESCRIPTION
Previously, only the ETH balance was displayed in the wallet view. With this pull request, I have added the ability to view the total balance as well as individual token balances for each token held in the wallet.
In addition, I have added a wallet activity calculation period to show the user how many days, weeks, and months they have been active on the network.
Please note that I am not familiar with Tailwind CSS, so I have not made any changes to the CSS. If necessary, please adjust the CSS accordingly.
Thank you for considering this pull request.


<img width="1411" alt="Xnip2023-05-28_14-16-58" src="https://github.com/ByFishh/zk-flow/assets/108685206/abaaf72d-20b1-4fc6-b997-272513c5469d">
